### PR TITLE
feat: Dockerfile to easy deploy on SaaS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM dunglas/frankenphp:php8.3
+
+# Be sure to replace "your-domain-name.example.com" by your domain name
+# ENV SERVER_NAME=your-domain-name.example.com
+# If you want to disable HTTPS, use this value instead:
+ENV SERVER_NAME=:80
+
+# Set the worker command
+ENV FRANKENPHP_CONFIG="worker ./public/worker.php"
+
+# Enable PHP production settings
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+# Install unzip
+RUN apt-get update && apt-get install -y unzip
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Copy the PHP files of your project in the public directory
+COPY . /app
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+RUN composer install --no-dev --optimize-autoloader --no-interaction --no-progress

--- a/composer.json
+++ b/composer.json
@@ -67,10 +67,13 @@
       "Composer\\Config::disableProcessTimeout",
       "php -S 0.0.0.0:8080 -t ./public/ ./public/server.php"
     ],
+    "franken": [
+      "Composer\\Config::disableProcessTimeout",
+      "docker run -e FRANKENPHP_CONFIG=\"worker ./public/worker.php\" -v $PWD:/app -p 8080:8080 -p 443:443 -p 443:443/udp --tty dunglas/frankenphp"
+    ],
     "optimize": "composer install --prefer-dist --optimize-autoloader --no-dev",
     "test": "./vendor/bin/pest tests",
     "phpstan": "./vendor/bin/phpstan analyse src",
-    "test-win": ".\\vendor\\bin\\pest tests",
     "prod": "composer production",
     "dev": "composer development",
     "production": [

--- a/public/worker.php
+++ b/public/worker.php
@@ -3,7 +3,7 @@
  * This script was made to be used in the "worker mode" of FrankenPHP.
  * For more details, see the documentation : https://frankenphp.dev/docs/worker/ .
  * ```bash
- * docker run -e FRANKENPHP_CONFIG="worker ./public/worker.php" -v $PWD:/app -p 80:8080 -p 443:443 -p 443:443/udp dunglas/frankenphp
+ * docker run -e FRANKENPHP_CONFIG="worker ./public/worker.php" -v $PWD:/app -p 80:8080 -p 443:443 -p 443:443/udp --tty dunglas/frankenphp
  * ```
  */
 

--- a/src/Listener/MonologListener.php
+++ b/src/Listener/MonologListener.php
@@ -130,6 +130,14 @@ class MonologListener
      */
     protected function isInformation(int $code): bool
     {
+        // If PHP version is 8.4 then do not include E_STRICT because it is deprecated (throws exception)
+        if (version_compare(PHP_VERSION, '8.4', '>=')) {
+            return in_array($code, [
+                E_DEPRECATED,
+                E_USER_DEPRECATED
+            ]);
+        }
+
         return in_array($code, [
             E_STRICT,
             E_DEPRECATED,

--- a/src/Repository/SQLitePeopleRepository.php
+++ b/src/Repository/SQLitePeopleRepository.php
@@ -117,7 +117,7 @@ class SQLitePeopleRepository implements PeopleRepositoryInterface
 
         $people->setLink(sprintf(
             '%s%s',
-            rtrim(env('APP_URL'), '/'),
+            rtrim(env('APP_URL', ''), '/'),
             $this->router->generateUri('peoples', $data)
         ));
 


### PR DESCRIPTION
- Dockerfile
- New `composer franken` command to start a FrankenPHP local dev server (instead of the PHP one)
- Fixed deprecation of E_STRICT constant
- Fixed an error SQLitePeopleRepository (PHP 8.4)